### PR TITLE
found out that dart default sort is unstable (sort order for equal elements may shuffeled)

### DIFF
--- a/lib/src/features/shared/model/comparator_order.dart
+++ b/lib/src/features/shared/model/comparator_order.dart
@@ -1,0 +1,10 @@
+/// Comparator helper class to define the order of the comparator during sorting.
+/// A comparator returns:
+///  - negative integer, when the first argument is less than the second
+/// - zero, when the first argument is equal to the second
+/// - positive integer, when the first argument is greater than the second
+class Order {
+  static const int preserve = 0;
+  static const int aFirst = -1;
+  static const int bFirst = 1;
+}

--- a/lib/src/features/training/widgets/calendar/filters/calendar_filter_row.dart
+++ b/lib/src/features/training/widgets/calendar/filters/calendar_filter_row.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:ksrvnjord_main_app/src/features/shared/model/comparator_order.dart';
 import 'package:ksrvnjord_main_app/src/features/shared/widgets/error.dart';
 import 'package:ksrvnjord_main_app/src/features/shared/widgets/future_wrapper.dart';
 import 'package:ksrvnjord_main_app/src/features/training/model/filters.dart';
@@ -30,19 +32,13 @@ class CalendarFilterRow extends StatelessWidget {
                         Set<String> selectedFiltersSet = selectedFilters
                             .toSet(); // O(1) lookup in set vs O(n) in list
 
-                        availableFilters.sort((a, b) {
+                        mergeSort(availableFilters, compare: (a, b) {
                           bool aSelected = selectedFiltersSet.contains(a.type);
                           bool bSelected = selectedFiltersSet.contains(b.type);
-                          if (aSelected == bSelected) {
-                            // preserve order if both are (un)selected. !a && !b || a && b
-                            return 0;
-                          } else if (aSelected && !bSelected) {
-                            // a should be first: a && !b
-                            return -1;
-                          }
 
-                          // b should be first: !a && b
-                          return 1;
+                          return aSelected == bSelected
+                              ? Order.preserve // if both (un)selected
+                              : (aSelected ? Order.aFirst : Order.bFirst);
                         });
 
                         return ListView(


### PR DESCRIPTION
Small fix that replaces unstable sort by stable merge sort.
Performance difference for small lists is neglible.