### PR TITLE
clear message when no results for almanak search

### DIFF
--- a/lib/src/features/profiles/widgets/almanak_scrolling_widget.dart
+++ b/lib/src/features/profiles/widgets/almanak_scrolling_widget.dart
@@ -71,7 +71,11 @@ class _AlmanakScrollingState extends State<AlmanakScrollingWidget> {
         builderDelegate: PagedChildBuilderDelegate<Query$Almanak$users$data>(
           itemBuilder: (context, item, index) => AlmanakUserButtonWidget(item),
           firstPageErrorIndicatorBuilder: (context) => const LoadingWidget(),
-          noItemsFoundIndicatorBuilder: (context) => const Text('404'),
+          noItemsFoundIndicatorBuilder: (context) => Column(
+            children: const [
+              Text('Geen Leeden gevonden met deze zoekterm.'),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
# Previous situation
User gets 404 shown when no almanak users found

# New situation
Users gets a comprehensive messages saying no users found