### PR TITLE
cupertino-context-menu-builds from root so has no access to Riverpod. We moved all riverpod stuff outside

### DIFF
--- a/lib/src/features/posts/widgets/author_widget.dart
+++ b/lib/src/features/posts/widgets/author_widget.dart
@@ -1,33 +1,30 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ksrvnjord_main_app/src/features/shared/model/firebase_user.dart';
 import 'package:styled_widget/styled_widget.dart';
 
-class AuthorWidget extends ConsumerWidget {
+class AuthorWidget extends StatelessWidget {
   final String authorName;
-  final String authorId;
+  final FirebaseUser? postAuthor;
   final double fontSize;
 
   const AuthorWidget({
     Key? key,
+    required this.postAuthor,
     required this.authorName,
-    required this.authorId,
     // ignore: no-magic-number
     this.fontSize = 18.0,
   }) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final postAuthor = ref.watch(firestoreUserProvider(authorId));
-
+  Widget build(BuildContext context) {
     return [
       Text(authorName).fontWeight(FontWeight.bold).fontSize(fontSize),
       // twitter checkmark
-      if (postAuthor != null && (postAuthor.isBestuur || postAuthor.isAppCo))
+      if (postAuthor != null && (postAuthor!.isBestuur || postAuthor!.isAppCo))
         Icon(
           Icons.verified,
           size: fontSize,
-          color: postAuthor.isAppCo ? Colors.amber : Colors.lightBlue,
+          color: postAuthor!.isAppCo ? Colors.amber : Colors.lightBlue,
         ),
     ].toRow(
       separator: const SizedBox(width: 4),

--- a/lib/src/features/posts/widgets/comment_card.dart
+++ b/lib/src/features/posts/widgets/comment_card.dart
@@ -2,13 +2,16 @@ import 'package:expandable_text/expandable_text.dart';
 import 'package:flutter/material.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/model/comment.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/widgets/author_widget.dart';
+import 'package:ksrvnjord_main_app/src/features/shared/model/firebase_user.dart';
 import 'package:styled_widget/styled_widget.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 class CommentCard extends StatelessWidget {
   final Comment comment;
+  final FirebaseUser? postAuthor;
 
-  const CommentCard({Key? key, required this.comment}) : super(key: key);
+  const CommentCard({Key? key, required this.postAuthor, required this.comment})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +22,7 @@ class CommentCard extends StatelessWidget {
     return [
       AuthorWidget(
         authorName: comment.authorName,
-        authorId: comment.authorId,
+        postAuthor: postAuthor,
         fontSize: authorNameFontSize,
       ),
       LimitedBox(

--- a/lib/src/features/posts/widgets/comment_widget.dart
+++ b/lib/src/features/posts/widgets/comment_widget.dart
@@ -2,15 +2,17 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/api/comments_service.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/model/comment.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/widgets/amount_of_likes_for_comment_widget.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/widgets/clickable_profile_picture_widget.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/widgets/comment_bottom_bar.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/widgets/comment_card.dart';
+import 'package:ksrvnjord_main_app/src/features/shared/model/firebase_user.dart';
 import 'package:styled_widget/styled_widget.dart';
 
-class CommentWidget extends StatelessWidget {
+class CommentWidget extends ConsumerWidget {
   final QueryDocumentSnapshot<Comment> snapshot;
 
   const CommentWidget({Key? key, required this.snapshot}) : super(key: key);
@@ -35,8 +37,9 @@ class CommentWidget extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final comment = snapshot.data();
+    final postAuthor = ref.watch(firestoreUserProvider(comment.authorId));
 
     const double cardPadding = 8;
     const double profilePictureSize = 20;
@@ -80,7 +83,7 @@ class CommentWidget extends StatelessWidget {
               ],
               child: SingleChildScrollView(
                 // we need to wrap the comment card in a scroll view because of a small issue with the ContextMenu: https://github.com/flutter/flutter/issues/58880#issuecomment-886175435
-                child: CommentCard(comment: comment),
+                child: CommentCard(comment: comment, postAuthor: postAuthor),
               ),
             ),
             // create positioned red circle

--- a/lib/src/features/posts/widgets/post_header_bar.dart
+++ b/lib/src/features/posts/widgets/post_header_bar.dart
@@ -1,5 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:ksrvnjord_main_app/src/features/posts/api/post_service.dart';
@@ -22,6 +21,8 @@ class PostHeaderBar extends ConsumerWidget {
     const double postTimeFontSize = 14;
     const double titleLeftPadding = 8;
 
+    final postAuthor = ref.watch(firestoreUserProvider(post.authorId));
+
     final firebaseUser = ref.watch(currentFirebaseUserProvider);
 
     void deletePost() {
@@ -36,7 +37,7 @@ class PostHeaderBar extends ConsumerWidget {
           size: profilePictureIconSize,
         ),
         [
-          AuthorWidget(authorName: post.authorName, authorId: post.authorId),
+          AuthorWidget(authorName: post.authorName, postAuthor: postAuthor),
           Text(timeago.format(post.createdTime.toDate(), locale: 'nl'))
               .textColor(Colors.blueGrey)
               .fontSize(postTimeFontSize),
@@ -48,8 +49,8 @@ class PostHeaderBar extends ConsumerWidget {
       ].toRow(),
       // three dots for more options, show if user is author
 
-      if (post.authorId == FirebaseAuth.instance.currentUser!.uid ||
-          (firebaseUser != null && firebaseUser.isBestuur))
+      if (firebaseUser != null &&
+          (post.authorId == firebaseUser.uid || firebaseUser.isBestuur))
         InkWell(
           onTap: () => showDialog(
             context: context,


### PR DESCRIPTION
# Vorige situatie
- Bij lang indrukken comment kreeg gebruiker grijs error blokje voor de comment te zien omdat CupertinoContextMenu geen toegang heeft tot Riverpod.

# Nieuwe situatie
- Alle Riverpod stuff buiten het contextmenu gehaald voor geen errors