### PR TITLE
[PES-474] Update admin page with new feature and links

### DIFF
--- a/lib/src/features/admin/pages/admin_page.dart
+++ b/lib/src/features/admin/pages/admin_page.dart
@@ -85,7 +85,8 @@ class AdminPage extends StatelessWidget {
               MoreLinkTile(
                 leading: Icon(Icons.directions_boat),
                 label: "Beheer Boten",
-                url: "https://heimdall.njord.nl/rowing/equipment",
+                url:
+                    "https://ksrvnjord.retool.com/apps/406a9678-8a53-11ee-8a54-d3ac821edb1c/Afschrijfsysteem%20-%20Objecten%20CRUD",
               ),
               ListTile(
                 leading: Icon(Icons.perm_identity, color: Colors.grey),

--- a/lib/src/features/admin/pages/admin_page.dart
+++ b/lib/src/features/admin/pages/admin_page.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:ksrvnjord_main_app/src/features/more/widgets/more_link_tile.dart';
 import 'package:ksrvnjord_main_app/src/features/profiles/edit_my_profile/widgets/form_section.dart';
 import 'package:styled_widget/styled_widget.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class AdminPage extends StatelessWidget {
   const AdminPage({super.key});
@@ -12,6 +14,8 @@ class AdminPage extends StatelessWidget {
     const double sectionPadding = 8;
 
     const double sectionVPadding = 8;
+
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
       appBar: AppBar(
@@ -23,6 +27,29 @@ class AdminPage extends StatelessWidget {
       ),
       body: ListView(
         children: [
+          // ignore: arguments-ordering
+          ExpansionTile(
+            leading: const Icon(Icons.info),
+            title: Text(
+              "We zijn op dit moment bezig met het vernieuwen van het admin panel. De app wordt het nieuwe startpunt voor admin-taken.",
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            // ignore: prefer-moving-to-variable, no-magic-number
+            backgroundColor: colorScheme.primaryContainer.withOpacity(0.2),
+            // ignore: no-equal-arguments
+            collapsedBackgroundColor:
+                // ignore: prefer-moving-to-variable, no-magic-number
+                colorScheme.primaryContainer.withOpacity(0.2),
+            children: const [
+              Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Text(
+                  "De AppCo is bezig met het vernieuwen van het admin panel. Het doel is om het makkelijker te maken om het admin panel te onderhouden en de functionaliteiten ervan uit te breiden. Het oude admin panel is nog steeds beschikbaar op https://heimdall.njord.nl/admin/. Heb je een vraag of opmerking over dit admin panel? Stuur het in #admin-panel-feedback op Slack, zodat we als AppCo er iets mee kunnen doen.",
+                ),
+              ),
+            ],
+          ),
+
           ListTile(
             leading: const Icon(Icons.warning_amber),
             title: const Text('Beheer vaarverbod'),
@@ -42,24 +69,39 @@ class AdminPage extends StatelessWidget {
             trailing: const Icon(Icons.arrow_forward_ios),
             onTap: () => context.goNamed('Manage Events'),
           ),
-          const MoreLinkTile(
-            leading: Icon(Icons.description),
-            label: "Beheer Polls",
-            url: "https://heimdall.njord.nl/polls",
+          ListTile(
+            leading: const Icon(Icons.description),
+            title: const Text("Beheer Polls"),
+            trailing: const Text("Heimdall"),
+            visualDensity: VisualDensity.standard,
+            // ignore: prefer-correct-handler-name
+            onTap: () => unawaited(launchUrl(Uri.parse(
+              "https://heimdall.njord.nl/admin/polls",
+            ))),
           ),
-          const MoreLinkTile(
-            leading: Icon(Icons.announcement),
-            label: "Beheer Aankondigingen",
-            url: "https://heimdall.njord.nl/announcements",
+          ListTile(
+            leading: const Icon(Icons.announcement),
+            title: const Text("Beheer Aankondigingen"),
+            trailing: const Text("Heimdall"),
+            visualDensity: VisualDensity.standard,
+            // ignore: prefer-correct-handler-name
+            onTap: () => unawaited(launchUrl(Uri.parse(
+              "https://heimdall.njord.nl/admin/announcements",
+            ))),
           ),
 
           FormSection(
             title: "Leedenadministratie",
             children: [
-              const MoreLinkTile(
-                leading: Icon(Icons.people),
-                label: "Beheer Leeden",
-                url: "https://heimdall.njord.nl/users",
+              ListTile(
+                leading: const Icon(Icons.people),
+                title: const Text("Beheer Leeden"),
+                trailing: const Text("Heimdall"),
+                visualDensity: VisualDensity.standard,
+                // ignore: prefer-correct-handler-name
+                onTap: () => unawaited(launchUrl(Uri.parse(
+                  "https://heimdall.njord.nl/admin/users",
+                ))),
               ),
               ListTile(
                 leading: const Icon(Icons.group),
@@ -69,26 +111,39 @@ class AdminPage extends StatelessWidget {
               ),
             ],
           ).paddingDirectional(vertical: sectionPadding),
-          const FormSection(
+          FormSection(
             title: 'Afschrijfsysteem',
             children: [
-              MoreLinkTile(
-                leading: Icon(Icons.calendar_today),
-                label: "Maak (herhalende) Afschrijving",
-                url: "https://heimdall.njord.nl/rowing/reservations/new",
-              ),
-              MoreLinkTile(
-                leading: Icon(Icons.warning),
-                label: "Beheer Schades",
-                url: "https://heimdall.njord.nl/rowing/damages",
-              ),
-              MoreLinkTile(
-                leading: Icon(Icons.directions_boat),
-                label: "Beheer Boten",
-                url:
-                    "https://ksrvnjord.retool.com/apps/406a9678-8a53-11ee-8a54-d3ac821edb1c/Afschrijfsysteem%20-%20Objecten%20CRUD",
+              ListTile(
+                leading: const Icon(Icons.calendar_today),
+                title: const Text("Maak (herhalende) Afschrijving"),
+                trailing: const Text("Heimdall"),
+                // ignore: prefer-correct-handler-name
+                onTap: () => unawaited(launchUrl(Uri.parse(
+                  "https://heimdall.njord.nl/admin/rowing/reservations/new",
+                ))),
               ),
               ListTile(
+                leading: const Icon(Icons.warning),
+                title: const Text("Beheer Schades"),
+                trailing: const Text("Heimdall"),
+                visualDensity: VisualDensity.standard,
+                // ignore: prefer-correct-handler-name
+                onTap: () => unawaited(launchUrl(Uri.parse(
+                  "https://heimdall.njord.nl/admin/rowing/damages",
+                ))),
+              ),
+              ListTile(
+                leading: const Icon(Icons.directions_boat),
+                title: const Text("Beheer boten"),
+                trailing: const Text("Retool"),
+                visualDensity: VisualDensity.standard,
+                // ignore: prefer-correct-handler-name
+                onTap: () => unawaited(launchUrl(Uri.parse(
+                  "https://ksrvnjord.retool.com/apps/406a9678-8a53-11ee-8a54-d3ac821edb1c/Afschrijfsysteem%20-%20Objecten%20CRUD",
+                ))),
+              ),
+              const ListTile(
                 leading: Icon(Icons.perm_identity, color: Colors.grey),
                 title: Text(
                   'Beheer permissies (Wordt nog aan gewerkt)',


### PR DESCRIPTION
This pull request updates the admin page with new features and links. It includes the following changes:

- Link beheer boten to retool instead of heimdall

- Update admin page with new features and links

@maxboone wil jij testen of de nieuwe retool feature om boten te beheren werkt vanuit de app? Ik heb je als gebruiker in Retool toegevoegd dus je hoeft alleen in te loggen in de app ervoor.