### PR TITLE
feat(training): new day after 17:26

### DIFF
--- a/lib/src/features/training/pages/all_training_page.dart
+++ b/lib/src/features/training/pages/all_training_page.dart
@@ -17,7 +17,7 @@ class AllTrainingPage extends ConsumerWidget {
 
     final currentUser = ref.watch(currentFirestoreUserProvider);
 
-    final DateTime now = DateTime.now();
+    final now = DateTime.now();
     final int isAfter1726 = (now.hour >= 17 && now.minute >= 26) ? 1 : 0;
     final int amountOfDaysUserCanBookInAdvance = currentUser
                     ?.canBookTrainingFarInAdvance ==

--- a/lib/src/features/training/pages/all_training_page.dart
+++ b/lib/src/features/training/pages/all_training_page.dart
@@ -16,7 +16,7 @@ class AllTrainingPage extends ConsumerWidget {
     final colorScheme = Theme.of(context).colorScheme;
 
     final currentUser = ref.watch(currentFirestoreUserProvider);
-    
+
     final DateTime now = DateTime.now();
     final int isAfter1726 = (now.hour >= 17 && now.minute >= 26) ? 1 : 0;
     final int amountOfDaysUserCanBookInAdvance = currentUser

--- a/lib/src/features/training/pages/all_training_page.dart
+++ b/lib/src/features/training/pages/all_training_page.dart
@@ -9,14 +9,16 @@ import 'package:styled_widget/styled_widget.dart';
 class AllTrainingPage extends ConsumerWidget {
   const AllTrainingPage({Key? key}) : super(key: key);
 
-  // Generate a list of the coming 14 days.
+  // Generate a list of the coming 14 days (+1 if after 17:26).
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colorScheme = Theme.of(context).colorScheme;
 
     final currentUser = ref.watch(currentFirestoreUserProvider);
-
+    
+    final DateTime now = DateTime.now();
+    final int isAfter1726 = (now.hour >= 17 && now.minute >= 26) ? 1 : 0;
     final int amountOfDaysUserCanBookInAdvance = currentUser
                     ?.canBookTrainingFarInAdvance ==
                 true ||
@@ -24,10 +26,10 @@ class AllTrainingPage extends ConsumerWidget {
             currentUser?.isAppCo == true
         ? 31 // Bestuur and AppCo and other users who are able to can book 28 days in the advance.
         : 4; // User can book 4 days in the advance.
-
+    
     final List<DateTime> days = List.generate(
-      amountOfDaysUserCanBookInAdvance,
-      (index) => DateTime.now().add(Duration(days: index)),
+      amountOfDaysUserCanBookInAdvance + isAfter1726,
+      (index) => now.add(Duration(days: index)),
     );
 
     return DefaultTabController(

--- a/lib/src/features/training/pages/all_training_page.dart
+++ b/lib/src/features/training/pages/all_training_page.dart
@@ -26,7 +26,7 @@ class AllTrainingPage extends ConsumerWidget {
             currentUser?.isAppCo == true
         ? 31 // Bestuur and AppCo and other users who are able to can book 28 days in the advance.
         : 4; // User can book 4 days in the advance.
-    
+
     final List<DateTime> days = List.generate(
       amountOfDaysUserCanBookInAdvance + isAfter1726,
       (index) => now.add(Duration(days: index)),


### PR DESCRIPTION
Adds another day to the shown planning days limit if it's currently or past 17:26.

Should work on prod, as the called firebase function does not verify whether users have permission to create a reservation in advance this far.