### PR TITLE
Old members correct show for substructuren

### DIFF
--- a/lib/src/features/profiles/edit_my_profile/pages/edit_almanak_profile_page.dart
+++ b/lib/src/features/profiles/edit_my_profile/pages/edit_almanak_profile_page.dart
@@ -192,8 +192,12 @@ class _EditAlmanakProfilePageState
                   // ignore: no-equal-arguments
                   buttonText: const Text('Substructuren'),
                   selectedColor: colorScheme.primaryContainer,
-                  backgroundColor: colorScheme.surface,
+                  backgroundColor: Colors.white,
                   checkColor: colorScheme.onPrimaryContainer,
+                  chipDisplay: MultiSelectChipDisplay(
+                    chipColor: colorScheme.primaryContainer,
+                    textStyle: TextStyle(color: colorScheme.onPrimaryContainer),
+                  ),
                   onSaved: (substructures) => ref
                       .read(profileEditFormNotifierProvider.notifier)
                       .setSubstructuren(substructures),

--- a/lib/src/features/profiles/substructures/widgets/leeden_list.dart
+++ b/lib/src/features/profiles/substructures/widgets/leeden_list.dart
@@ -28,6 +28,9 @@ class LeedenList extends StatelessWidget {
         almanakProfileSnapshot.docs;
     if (compare != null) {
       docs.sort(compare); // For ordering based on functions of the members.
+    } else {
+      docs.sort((a, b) => b.data().identifier.compareTo(
+          a.data().identifier)); // Sort by identifier in descending order
     }
 
     const double notFoundPadding = 16;

--- a/lib/src/features/profiles/widgets/almanak_user_tile.dart
+++ b/lib/src/features/profiles/widgets/almanak_user_tile.dart
@@ -31,42 +31,46 @@ class AlmanakUserTile extends ConsumerWidget {
     const double subtitleShimmerPadding = 64;
 
     return user.when(
-      data: (u) => ListTile(
-        leading: ProfilePictureListTileWidget(profileId: lidnummer),
-        title: Text("$firstName $lastName"),
-        subtitle: subtitle != null ? Text(subtitle as String) : null,
-        trailing: Icon(
-          Icons.arrow_forward_ios,
-          color: Theme.of(context).colorScheme.primary,
-        ),
-        onTap: () => context
-            .pushNamed("Lid", pathParameters: {"id": u.identifier.toString()}),
-      ),
-      loading: () => ListTile(
-        leading: const ShimmerWidget(child: DefaultProfilePicture()),
-        title: ShimmerWidget(
-          child: Container(
-            decoration: ShapeDecoration(
-              color: Colors.grey[300],
-              shape: const RoundedRectangleBorder(),
+        data: (u) {
+          return ListTile(
+            leading: ProfilePictureListTileWidget(profileId: lidnummer),
+            title: Text("$firstName $lastName"),
+            subtitle: subtitle != null ? Text(subtitle as String) : null,
+            trailing: Icon(
+              Icons.arrow_forward_ios,
+              color: Theme.of(context).colorScheme.primary,
             ),
-            height: titleShimmerHeight,
-          ),
-        ).padding(right: titleShimmerPadding),
-        subtitle: subtitle == null
-            ? null
-            : ShimmerWidget(
+            onTap: () => context.pushNamed("Lid",
+                pathParameters: {"id": u.identifier.toString()}),
+          );
+        },
+        loading: () => ListTile(
+              leading: const ShimmerWidget(child: DefaultProfilePicture()),
+              title: ShimmerWidget(
                 child: Container(
                   decoration: ShapeDecoration(
                     color: Colors.grey[300],
                     shape: const RoundedRectangleBorder(),
                   ),
-                  height: subtitleShimmerHeight,
+                  height: titleShimmerHeight,
                 ),
-              ).padding(right: subtitleShimmerPadding),
-      ),
-      error: (error, stackTrace) =>
-          ErrorCardWidget(errorMessage: error.toString()),
-    ); // Show nothing if no heimdall user is found.
+              ).padding(right: titleShimmerPadding),
+              subtitle: subtitle == null
+                  ? null
+                  : ShimmerWidget(
+                      child: Container(
+                        decoration: ShapeDecoration(
+                          color: Colors.grey[300],
+                          shape: const RoundedRectangleBorder(),
+                        ),
+                        height: subtitleShimmerHeight,
+                      ),
+                    ).padding(right: subtitleShimmerPadding),
+            ),
+        error: (error, stackTrace) => ListTile(
+              leading: ProfilePictureListTileWidget(profileId: lidnummer),
+              title: Text("$firstName $lastName"),
+              subtitle: subtitle != null ? Text(subtitle as String) : null,
+            )); // Show nothing if no heimdall user is found.
   }
 }

--- a/linux/flutter/ephemeral/.plugin_symlinks/autologin_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/autologin_linux
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/autologin_linux-1.0.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/device_info_plus
+++ b/linux/flutter/ephemeral/.plugin_symlinks/device_info_plus
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/device_info_plus-10.1.2/

--- a/linux/flutter/ephemeral/.plugin_symlinks/file_selector_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/file_selector_linux
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/file_selector_linux-0.9.3+2/

--- a/linux/flutter/ephemeral/.plugin_symlinks/flutter_local_notifications_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/flutter_local_notifications_linux
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/flutter_local_notifications_linux-4.0.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/flutter_secure_storage_linux
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/flutter_secure_storage_linux-1.2.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/image_picker_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/image_picker_linux
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/image_picker_linux-0.2.1+1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/package_info_plus
+++ b/linux/flutter/ephemeral/.plugin_symlinks/package_info_plus
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/package_info_plus-8.1.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/path_provider_linux-2.2.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/share_plus
+++ b/linux/flutter/ephemeral/.plugin_symlinks/share_plus
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/share_plus-10.0.0/

--- a/linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/shared_preferences_linux
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/shared_preferences_linux-2.4.1/

--- a/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
+++ b/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
@@ -1,0 +1,1 @@
+/home/pim/.pub-cache/hosted/pub.dev/url_launcher_linux-3.2.1/


### PR DESCRIPTION
Old members cannot be retrieved anymore other than name and lidnummer. Insttead of an error widget it shows listTile that do not link to a almanakpage. Also, list is sorted on lidnummers so the old members are at the bottom.